### PR TITLE
Add retry mechanism for email verification

### DIFF
--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -1,4 +1,5 @@
 # email_service.py
+import asyncio
 from builtins import ValueError, dict, str
 from settings.config import settings
 from app.utils.smtp_connection import SMTPClient
@@ -28,10 +29,28 @@ class EmailService:
         html_content = self.template_manager.render_template(email_type, **user_data)
         self.smtp_client.send_email(subject_map[email_type], html_content, user_data['email'])
 
-    async def send_verification_email(self, user: User):
+    async def send_verification_email(self, user: User, max_retries: int = 3):
+        """
+        Send a verification email with retry logic.
+
+        Args:
+            user (User): The user to whom the email is sent.
+            max_retries (int): Maximum number of retry attempts.
+        """
         verification_url = f"{settings.server_base_url}verify-email/{user.id}/{user.verification_token}"
-        await self.send_user_email({
+        user_data = {
             "name": user.first_name,
             "verification_url": verification_url,
             "email": user.email
-        }, 'email_verification')
+        }
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                await self.send_user_email(user_data, 'email_verification')
+                print(f"Verification email sent successfully to {user.email}")
+                break  # Exit the loop if successful
+            except Exception as e:
+                print(f"Attempt {attempt}: Failed to send email to {user.email} - {str(e)}")
+                if attempt == max_retries:
+                    raise Exception(f"Failed to send verification email after {max_retries} attempts") from e
+                await asyncio.sleep(2 ** attempt)  # Exponential backoff before retrying


### PR DESCRIPTION
The email verification endpoint /verify-email/{user_id}/{token} lacks a retry mechanism for users who might fail to verify their email within the token's validity period. This can result in users being unable to access their accounts if the verification token has expired or they lose the email.